### PR TITLE
Update logger.ts

### DIFF
--- a/askui_example/logging/logger.ts
+++ b/askui_example/logging/logger.ts
@@ -14,8 +14,8 @@ const workspaceId = process.env.ASKUI_WORKSPACE_ID || 'default-workspace-id';
 // Define environment info by creating function in allure. 
 allure.writeEnvironmentInfo({
     APP_URL: `https://app.askui.com/workspaces/${workspaceId}/quick-start`,
-    Device_ID: deviceId,
-    Workspace_ID: workspaceId,
+    DEVICE_ID: deviceId,
+    WORKSPACE_ID: workspaceId,
     TEST_RUNNER: 'Jest',
     PLATFORM: os.platform(),
     OS_VERSION: os.release(),

--- a/askui_example/logging/logger.ts
+++ b/askui_example/logging/logger.ts
@@ -1,24 +1,6 @@
 import "@askui/jest-allure-circus";
 import * as os from 'os';
 
-
-
-// Generate environment info
-const hostname = `${os.hostname()}`;
-const workspaceId = process.env.ASKUI_WORKSPACE_ID || 'default-workspace-id';
-
-// Define environment info by creating function in allure. 
-allure.writeEnvironmentInfo({
-    APP_URL: `https://app.askui.com/workspaces/${workspaceId}/quick-start`,
-    DEVICE_ID: deviceId,
-    WORKSPACE_ID: workspaceId,
-    TEST_RUNNER: 'Jest',
-    PLATFORM: os.platform(),
-    OS_VERSION: os.release(),
-    NODE_VERSION: process.version,
-    TIMESTAMP: new Date().toISOString()
-});
-
 export const logger = {
     error: (message: string, error?: any) => {
         allure.step('❌ ERROR: ' + message, () => {
@@ -47,3 +29,18 @@ export const logger = {
         });
     }
 };
+beforeAll(async () => {
+    const hostname = os.hostname();
+    const workspaceId = process.env.ASKUI_WORKSPACE_ID || 'default-workspace-id';
+
+    allure.writeEnvironmentInfo({
+        APP_URL: `https://app.askui.com/workspaces/${workspaceId}/quick-start`,
+        HOSTNAME: hostname,
+        WORKSPACE_ID: workspaceId,
+        TEST_RUNNER: 'Jest',
+        PLATFORM: os.platform(),
+        OS_VERSION: os.release(),
+        NODE_VERSION: process.version,
+        TIMESTAMP: new Date().toISOString()
+    });
+});

--- a/askui_example/logging/logger.ts
+++ b/askui_example/logging/logger.ts
@@ -1,9 +1,27 @@
 import "@askui/jest-allure-circus";
+import * as os from 'os';
 
 declare const allure: {
     step(name: string, body?: () => void): void;
     attachment(name: string, content: string, type: string): void;
+    writeEnvironmentInfo(info: Record<string, string>): void;
 }
+
+// Generate environment info
+const deviceId = `${os.hostname()}-${Math.random().toString(36).substring(2, 8).toUpperCase()}`;
+const workspaceId = process.env.ASKUI_WORKSPACE_ID || 'default-workspace-id';
+
+// Define environment info by creating function in allure. 
+allure.writeEnvironmentInfo({
+    APP_URL: `https://app.askui.com/workspaces/${workspaceId}/quick-start`,
+    Device_ID: deviceId,
+    Workspace_ID: workspaceId,
+    TEST_RUNNER: 'Jest',
+    PLATFORM: os.platform(),
+    OS_VERSION: os.release(),
+    NODE_VERSION: process.version,
+    TIMESTAMP: new Date().toISOString()
+});
 
 export const logger = {
     error: (message: string, error?: any) => {

--- a/askui_example/logging/logger.ts
+++ b/askui_example/logging/logger.ts
@@ -8,7 +8,7 @@ declare const allure: {
 }
 
 // Generate environment info
-const deviceId = `${os.hostname()}-${Math.random().toString(36).substring(2, 8).toUpperCase()}`;
+const hostname = `${os.hostname()}`;
 const workspaceId = process.env.ASKUI_WORKSPACE_ID || 'default-workspace-id';
 
 // Define environment info by creating function in allure. 

--- a/askui_example/logging/logger.ts
+++ b/askui_example/logging/logger.ts
@@ -1,11 +1,7 @@
 import "@askui/jest-allure-circus";
 import * as os from 'os';
 
-declare const allure: {
-    step(name: string, body?: () => void): void;
-    attachment(name: string, content: string, type: string): void;
-    writeEnvironmentInfo(info: Record<string, string>): void;
-}
+
 
 // Generate environment info
 const hostname = `${os.hostname()}`;


### PR DESCRIPTION
Added new env variables to allure report in logger that displays APP_URL: `https://app.askui.com/workspaces/${workspaceId}/quick-start`,
    Device_ID
    Workspace_ID
    TEST_RUNNER
    PLATFORM
    OS_VERSION
    NODE_VERSION
    TIMESTAMP